### PR TITLE
remove non-existing commands from the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,8 +589,6 @@ The Kubiya CLI provides comprehensive MCP integration for AI-powered application
 ### Quick MCP Setup
 
 ```bash
-# Interactive setup with guided configuration
-kubiya mcp install
 
 # List available serverless agents for MCP
 kubiya agent list
@@ -598,12 +596,6 @@ kubiya agent list
 # Set up MCP with specific agents
 export AGENT_UUIDS="abc-123,def-456"  # comma-separated agent UUIDs
 kubiya mcp setup
-
-# Apply configuration to Claude Desktop
-kubiya mcp apply claude_desktop
-
-# Apply configuration to Cursor IDE
-kubiya mcp apply cursor_ide
 ```
 
 ### MCP Server Management
@@ -722,20 +714,6 @@ kubiya webhook update abc-123 --name "Updated Alert Handler"
 kubiya webhook delete abc-123
 ```
 
-## Configuration Management ⚙️
-
-### Initialize Configuration
-
-```bash
-# Create initial configuration
-kubiya config init
-
-# Set default values
-kubiya config set default_runner k8s-runner
-kubiya config set default_timeout 300s
-kubiya config set debug_mode true
-```
-
 ### Environment-Specific Configuration
 
 ```bash
@@ -789,8 +767,6 @@ export KUBIYA_DEFAULT_RUNNER="dev-runner"
 # Verify API key
 kubiya agent list
 
-# Check configuration
-kubiya config show
 
 # Test with debug mode
 export KUBIYA_DEBUG=true

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -121,8 +121,7 @@ make build && make install</code></pre>
         <div class="example-grid">
             <div class="example-card">
                 <h3>1. Configure Authentication</h3>
-                <pre><code class="language-bash">export KUBIYA_API_KEY="your-api-key"
-kubiya config init</code></pre>
+                <pre><code class="language-bash">export KUBIYA_API_KEY="your-api-key"</code></pre>
             </div>
             
             <div class="example-card">

--- a/docs-site/pages/commands.md
+++ b/docs-site/pages/commands.md
@@ -696,12 +696,12 @@ kubiya webhook delete WEBHOOK_UUID [OPTIONS]
 
 ## MCP Integration
 
-### kubiya mcp install
+### kubiya mcp setup
 
-Install and configure MCP integration.
+Configure MCP integration.
 
 ```bash
-kubiya mcp install [OPTIONS]
+kubiya mcp setup [OPTIONS]
 ```
 
 **Options:**
@@ -711,10 +711,8 @@ kubiya mcp install [OPTIONS]
 **Examples:**
 ```bash
 # Interactive installation
-kubiya mcp install
+kubiya mcp setup
 
-# Force reinstall
-kubiya mcp install --force
 ```
 
 ### kubiya mcp serve
@@ -740,113 +738,6 @@ kubiya mcp serve --config ~/.kubiya/mcp-config.json
 
 # Start with verbose logging
 kubiya mcp serve --verbose
-```
-
-### kubiya mcp apply
-
-Apply MCP configuration to client applications.
-
-```bash
-kubiya mcp apply CLIENT [OPTIONS]
-```
-
-**Clients:**
-- `claude_desktop`: Claude Desktop application
-- `cursor_ide`: Cursor IDE
-
-**Examples:**
-```bash
-# Apply to Claude Desktop
-kubiya mcp apply claude_desktop
-
-# Apply to Cursor IDE
-kubiya mcp apply cursor_ide
-```
-
-### kubiya mcp test
-
-Test MCP server functionality.
-
-```bash
-kubiya mcp test [OPTIONS]
-```
-
-**Options:**
-- `--config`: Configuration file to test
-- `--tool`: Test specific tool
-
-**Examples:**
-```bash
-# Test server functionality
-kubiya mcp test
-
-# Test with specific config
-kubiya mcp test --config test-config.json
-
-# Test specific tool
-kubiya mcp test --tool kubectl
-```
-
-## Configuration Management
-
-### kubiya config init
-
-Initialize configuration file.
-
-```bash
-kubiya config init [OPTIONS]
-```
-
-**Options:**
-- `--force`: Overwrite existing configuration
-
-**Examples:**
-```bash
-# Initialize config
-kubiya config init
-
-# Force overwrite
-kubiya config init --force
-```
-
-### kubiya config set
-
-Set configuration value.
-
-```bash
-kubiya config set KEY VALUE [OPTIONS]
-```
-
-**Examples:**
-```bash
-# Set default runner
-kubiya config set default_runner k8s-runner
-
-# Set debug mode
-kubiya config set debug true
-
-# Set timeout
-kubiya config set timeout 300s
-```
-
-### kubiya config show
-
-Show current configuration.
-
-```bash
-kubiya config show [OPTIONS]
-```
-
-**Options:**
-- `--key`: Show specific key value
-
-**Examples:**
-```bash
-# Show all configuration
-kubiya config show
-
-# Show specific key
-kubiya config show --key default_runner
 ```
 
 ## Integration Management
@@ -928,7 +819,6 @@ kubiya version --build-info
 | `KUBIYA_API_KEY` | API key for authentication | Required |
 | `KUBIYA_BASE_URL` | Base URL for API | `https://api.kubiya.ai/api/v1` |
 | `KUBIYA_DEBUG` | Enable debug logging | `false` |
-| `KUBIYA_CONFIG` | Path to config file | `~/.kubiya/config.yaml` |
 | `KUBIYA_DEFAULT_RUNNER` | Default runner name | None |
 | `KUBIYA_TIMEOUT` | Default timeout | `300s` |
 

--- a/docs-site/pages/installation.md
+++ b/docs-site/pages/installation.md
@@ -109,9 +109,6 @@ kubiya version
 
 # Check help
 kubiya --help
-
-# Test basic functionality
-kubiya config init
 ```
 
 Expected output:
@@ -139,14 +136,6 @@ export KUBIYA_DEBUG=true
 
 # Optional: Default runner
 export KUBIYA_DEFAULT_RUNNER="my-runner"
-```
-
-### Configuration File
-
-Initialize a configuration file:
-
-```bash
-kubiya config init
 ```
 
 This creates `~/.kubiya/config.yaml` with default settings:

--- a/docs-site/pages/mcp.md
+++ b/docs-site/pages/mcp.md
@@ -26,7 +26,7 @@ The fastest way to get started:
 
 ```bash
 # Interactive setup with guided configuration
-kubiya mcp install
+kubiya mcp setup
 ```
 
 This will:
@@ -48,10 +48,6 @@ export AGENT_UUIDS="abc-123,def-456"
 
 # 3. Set up MCP server
 kubiya mcp setup
-
-# 4. Apply to specific applications
-kubiya mcp apply claude_desktop
-kubiya mcp apply cursor_ide
 ```
 
 ## Configuration

--- a/docs-site/pages/quickstart.md
+++ b/docs-site/pages/quickstart.md
@@ -30,13 +30,6 @@ echo 'export KUBIYA_API_KEY="your-api-key-here"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-### Initialize Configuration
-
-Create your configuration file:
-
-```bash
-kubiya config init
-```
 
 This creates `~/.kubiya/config.yaml` with default settings. You can customize it as needed.
 
@@ -219,11 +212,8 @@ kubiya source list
 
 ### MCP Integration
 
-Set up MCP integration for Claude Desktop:
-
 ```bash
-kubiya mcp install
-kubiya mcp apply claude_desktop
+kubiya mcp setup
 ```
 
 ### Secret Management

--- a/docs-site/pages/troubleshooting.md
+++ b/docs-site/pages/troubleshooting.md
@@ -25,9 +25,6 @@ kubiya agent list --verbose
 # Check CLI version
 kubiya version --build-info
 
-# Check configuration
-kubiya config show
-
 # Test basic connectivity
 kubiya agent list
 ```
@@ -65,9 +62,6 @@ Error: API key not found
 ```bash
 # Set API key as environment variable
 export KUBIYA_API_KEY="your-api-key"
-
-# Or use config file
-kubiya config set api_key "your-api-key"
 
 # Or pass as flag
 kubiya --api-key "your-api-key" agent list
@@ -120,24 +114,6 @@ export KUBIYA_SKIP_SSL_VERIFY=true
 
 # Or specify custom CA bundle
 export KUBIYA_CA_BUNDLE="/path/to/ca-bundle.pem"
-```
-
-### Proxy Configuration
-
-**Error:**
-```
-Error: connection refused
-```
-
-**Solutions:**
-```bash
-# Set proxy environment variables
-export HTTP_PROXY="http://proxy.company.com:8080"
-export HTTPS_PROXY="http://proxy.company.com:8080"
-export NO_PROXY="localhost,127.0.0.1,.company.com"
-
-# Or use kubiya-specific proxy settings
-kubiya config set proxy_url "http://proxy.company.com:8080"
 ```
 
 ## Agent Issues
@@ -482,8 +458,6 @@ curl -I https://api.kubiya.ai/health
 # Use different runner
 kubiya tool exec --runner faster-runner --name "test" --content "echo test"
 
-# Reduce concurrent operations
-kubiya config set max_concurrent_requests 2
 
 # Check network latency
 ping api.kubiya.ai
@@ -560,13 +534,6 @@ Error: config file not found
 ```bash
 # Create config directory
 mkdir -p ~/.kubiya
-
-# Initialize configuration
-kubiya config init
-
-# Set config path manually
-export KUBIYA_CONFIG=~/.kubiya/config.yaml
-```
 
 ### Invalid Configuration
 


### PR DESCRIPTION
Add End-to-End Setup Guide for MCP Clients Connecting to Kubiya MCP Server via CLI