### PR TITLE
CORE-1164: Enable Inline Agent Flow in CLi to work 

### DIFF
--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -48,12 +48,12 @@ type connectionStatus struct {
 
 // Add tool call statistics
 type toolCallStats struct {
-	totalCalls    int
-	activeCalls   int
+	totalCalls     int
+	activeCalls    int
 	completedCalls int
-	failedCalls   int
-	toolTypes     map[string]int
-	mu            sync.RWMutex
+	failedCalls    int
+	toolTypes      map[string]int
+	mu             sync.RWMutex
 }
 
 // Add a buffer for chat messages
@@ -74,10 +74,10 @@ const (
 
 func newChatCommand(cfg *config.Config) *cobra.Command {
 	var (
-		agentID   string
-		agentName string
-		message      string
-		noClassify   bool
+		agentID    string
+		agentName  string
+		message    string
+		noClassify bool
 
 		interactive     bool
 		debug           bool
@@ -91,19 +91,19 @@ func newChatCommand(cfg *config.Config) *cobra.Command {
 		sourceName      string
 		suggestTool     string
 		permissionLevel string
-		
+
 		// Inline agent flags
-		inline          bool
-		toolsFile       string
-		toolsJSON       string
-		aiInstructions  string
-		description     string
-		runners         []string
-		integrations    []string
-		secrets         []string
-		envVars         []string
-		llmModel        string
-		isDebugMode     bool
+		inline         bool
+		toolsFile      string
+		toolsJSON      string
+		aiInstructions string
+		description    string
+		runners        []string
+		integrations   []string
+		secrets        []string
+		envVars        []string
+		llmModel       string
+		isDebugMode    bool
 	)
 
 	// Helper function to fetch content from URL
@@ -307,6 +307,9 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 				if llmModel == "" {
 					llmModel = "azure/gpt-4-32k"
 				}
+				if len(integrations) == 0 {
+					integrations = []string{}
+				}
 			}
 
 			// Session storage file path
@@ -398,24 +401,24 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 					toolTypes: make(map[string]int),
 				}
 				rawEventLogging = os.Getenv("KUBIYA_RAW_EVENTS") == "1" || debug
-				msgChan        <-chan kubiya.ChatMessage
+				msgChan         <-chan kubiya.ChatMessage
 			)
 
 			// Handle inline agent
 			if inline {
 				var tools []kubiya.Tool
-				
+
 				// Parse tools from file or JSON
 				if toolsFile != "" {
 					if debug {
 						fmt.Printf("🔍 Loading tools from file: %s\n", toolsFile)
 					}
-					
+
 					toolsData, err := os.ReadFile(toolsFile)
 					if err != nil {
 						return fmt.Errorf("failed to read tools file: %w", err)
 					}
-					
+
 					tools, err = parseTools(string(toolsData))
 					if err != nil {
 						return fmt.Errorf("failed to parse tools from file: %w", err)
@@ -424,26 +427,31 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 					if debug {
 						fmt.Printf("🔍 Parsing tools from JSON string\n")
 					}
-					
+
 					tools, err = parseTools(toolsJSON)
 					if err != nil {
 						return fmt.Errorf("failed to parse tools from JSON: %w", err)
 					}
 				}
-				
+
 				// Validate tools
 				for i, tool := range tools {
 					if err := validateTool(tool); err != nil {
 						return fmt.Errorf("tool validation failed for tool %d (%s): %w", i, tool.Name, err)
 					}
 				}
-				
+
 				// Parse environment variables
 				envVarsMap, err := parseEnvVars(envVars)
 				if err != nil {
 					return fmt.Errorf("failed to parse environment variables: %w", err)
 				}
-				
+
+				// Add KUBIYA_RUNNER if runners are specified
+				if len(runners) > 0 {
+					envVarsMap["KUBIYA_RUNNER"] = runners[0]
+				}
+
 				if debug {
 					fmt.Printf("🤖 Creating inline agent with %d tools\n", len(tools))
 					fmt.Printf("📋 Tools: %v\n", func() []string {
@@ -454,52 +462,97 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 						return names
 					}())
 				}
-				
+
 				// Convert tools to the correct format for inline agent
 				inlineTools := make([]map[string]interface{}, len(tools))
 				for i, tool := range tools {
+					// Ensure args is an empty slice if nil
+					args := tool.Args
+					if args == nil {
+						args = []kubiya.ToolArg{}
+					}
+
+					// Ensure env is an empty slice if nil
+					env := tool.Env
+					if env == nil {
+						env = []string{}
+					}
+
+					// Ensure with_files is an empty slice if nil
+					withFiles := tool.WithFiles
+					if withFiles == nil {
+						withFiles = []interface{}{}
+					}
+
+					// Ensure with_volumes is an empty slice if nil
+					withVolumes := tool.WithVolumes
+					if withVolumes == nil {
+						withVolumes = []interface{}{}
+					}
+
 					inlineTools[i] = map[string]interface{}{
 						"name":         tool.Name,
-						"description":  tool.Description,
-						"content":      tool.Content,
-						"args":         tool.Args,
-						"env":          tool.Env,
-						"secrets":      tool.Secrets,
-						"image":        tool.Image,
-						"icon_url":     tool.IconURL,
 						"alias":        tool.Alias,
-						"with_files":   tool.WithFiles,
-						"with_volumes": tool.WithVolumes,
+						"description":  tool.Description,
+						"type":         tool.Type,
+						"content":      tool.Content,
+						"args":         args,
+						"env":          env,
+						"image":        tool.Image,
+						"with_files":   withFiles,
+						"with_volumes": withVolumes,
 					}
 				}
-				
+
 				// Create inline agent request - use the same message handling as regular agents
-				msgChan, err = client.SendInlineAgentMessage(cmd.Context(), message, sessionID, context, map[string]interface{}{
-					"uuid":                nil,
-					"name":                "inline",
-					"description":         description,
-					"ai_instructions":     aiInstructions,
-					"tools":               inlineTools,
-					"runners":             runners,
-					"integrations":        integrations,
-					"secrets":             secrets,
+				inlineAgent := map[string]interface{}{
+					"uuid":                  nil,
+					"name":                  "inline",
+					"description":           description,
+					"ai_instructions":       aiInstructions,
+					"tools":                 inlineTools,
+					"runners":               runners,
+					"integrations":          integrations,
+					"secrets":               secrets,
 					"environment_variables": envVarsMap,
-					"llm_model":           llmModel,
-					"is_debug_mode":       isDebugMode,
-					"owners":              []string{},
-					"allowed_users":       []string{},
-					"allowed_groups":      []string{},
-					"starters":            []interface{}{},
-					"tasks":               []string{},
-					"sources":             []string{},
-					"links":               []string{},
-					"image":               "",
-					"additional_data":     map[string]interface{}{},
-				})
+					"llm_model":             llmModel,
+					"is_debug_mode":         true, // Always true for inline agents to capture tool output
+					"owners":                []string{},
+					"allowed_users":         []string{},
+					"allowed_groups":        []string{},
+					"starters":              []interface{}{},
+					"tasks":                 []string{},
+					"sources":               []string{},
+					"links":                 []string{},
+					"image":                 "",
+					"additional_data":       map[string]interface{}{},
+				}
+
+				if debug {
+					fmt.Printf("🔍 CLI: Creating inline agent with payload:\n")
+					if jsonPayload, err := json.MarshalIndent(inlineAgent, "", "  "); err == nil {
+						fmt.Printf("Agent Definition: %s\n", string(jsonPayload))
+					}
+					fmt.Printf("Message: %s\n", message)
+					fmt.Printf("SessionID: %s\n", sessionID)
+					fmt.Printf("Context files: %d\n", len(context))
+					fmt.Printf("User Email: %s\n", os.Getenv("KUBIYA_USER_EMAIL"))
+					fmt.Printf("Organization: %s\n", os.Getenv("KUBIYA_ORG"))
+					apiKey := os.Getenv("KUBIYA_API_KEY")
+					if len(apiKey) > 20 {
+						fmt.Printf("API Key: %s\n", apiKey[:20]+"...")
+					} else {
+						fmt.Printf("API Key: %s\n", apiKey)
+					}
+					fmt.Printf("Base URL: %s\n", cfg.BaseURL)
+					fmt.Printf("Debug mode: %v\n", debug)
+				}
+
+				msgChan, err = client.SendInlineAgentMessage(cmd.Context(), message, sessionID, context, inlineAgent)
 				if err != nil {
 					return err
 				}
-				
+
 				// Set agentID for inline agent to use the same processing logic
 				agentID = "inline"
 			}
@@ -524,9 +577,8 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 
 				// Create HTTP request
 				baseURL := strings.TrimSuffix(cfg.BaseURL, "/")
-				if strings.HasSuffix(baseURL, "/api/v1") {
-					baseURL = strings.TrimSuffix(baseURL, "/api/v1")
-				}
+				baseURL = strings.TrimSuffix(baseURL, "/api/v1")
+
 				classifyURL := fmt.Sprintf("%s/http-bridge/v1/classify/agent", baseURL)
 				req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, classifyURL, bytes.NewBuffer(reqJSON))
 				if err != nil {
@@ -638,13 +690,13 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 				connected:   false,
 				connectTime: time.Now(),
 			}
-			
+
 			// Show enhanced connection status
 			fmt.Printf("%s\n", style.InfoBoxStyle.Render(
-				fmt.Sprintf("🔗 Connecting to agent runner service at: runner://%s (%s)", 
+				fmt.Sprintf("🔗 Connecting to agent runner service at: runner://%s (%s)",
 					connStatus.runner, connStatus.runnerType)))
 			fmt.Printf("%s\n", style.SpinnerStyle.Render("⏳ Establishing secure connection..."))
-			
+
 			// Send message with context, with retry mechanism for robustness (skip for inline agents)
 			if !inline {
 				msgChan, err = client.SendMessageWithContext(cmd.Context(), agentID, enhancedMessage, sessionID, context)
@@ -661,13 +713,13 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 					}
 				}
 			}
-			
+
 			// Connection established
 			connStatus.connected = true
 			connStatus.lastPing = time.Now()
 			connStatus.latency = time.Since(connStatus.connectTime)
 			fmt.Printf("\r%s\n", style.SuccessStyle.Render(
-				fmt.Sprintf("✅ Connected to runner://%s (%s) - latency: %v", 
+				fmt.Sprintf("✅ Connected to runner://%s (%s) - latency: %v",
 					connStatus.runner, connStatus.runnerType, connStatus.latency)))
 
 			// Read messages and handle session ID
@@ -688,17 +740,17 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 			// Update the message handling loop:
 			for msg := range msgChan {
 				if msg.Error != "" {
-					fmt.Fprintf(os.Stderr, "%s\n", style.ErrorStyle.Render("❌ Error: " + msg.Error))
+					fmt.Fprintf(os.Stderr, "%s\n", style.ErrorStyle.Render("❌ Error: "+msg.Error))
 					hasError = true
 					return fmt.Errorf("error from server: %s", msg.Error)
 				}
-				
+
 				// Raw event logging for debugging
 				if rawEventLogging {
 					fmt.Printf("[RAW EVENT] Type: %s, Content: %s, MessageID: %s, Final: %v, SessionID: %s\n",
 						msg.Type, msg.Content, msg.MessageID, msg.Final, msg.SessionID)
 				}
-				
+
 				// Capture completion reason and session ID from final messages
 				if msg.Final && msg.FinishReason != "" {
 					completionReason = msg.FinishReason
@@ -709,7 +761,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 
 				// Handle system messages
 				if msg.Type == systemMsg {
-					fmt.Fprintf(os.Stderr, "%s\n", style.SystemStyle.Render("🔄 " + msg.Content))
+					fmt.Fprintf(os.Stderr, "%s\n", style.SystemStyle.Render("🔄 "+msg.Content))
 					continue
 				}
 
@@ -742,7 +794,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 								toolStats.activeCalls++
 								toolStats.toolTypes[toolName]++
 								toolStats.mu.Unlock()
-								
+
 								// Create new tool execution
 								te := &toolExecution{
 									name:       toolName,
@@ -758,7 +810,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 
 								// Enhanced tool execution header with better UX and stats
 								fmt.Printf("\n")
-								
+
 								// Show tool statistics inline
 								toolStats.mu.RLock()
 								statsStr := fmt.Sprintf("[%d/%d tools]", toolStats.activeCalls, toolStats.totalCalls)
@@ -766,13 +818,13 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 									statsStr = fmt.Sprintf("[+%d active tools]", toolStats.activeCalls)
 								}
 								toolStats.mu.RUnlock()
-								
+
 								fmt.Printf("%s\n", style.InfoBoxStyle.Render(
-									fmt.Sprintf("🚀 %s %s %s", 
-										style.ToolNameStyle.Render("EXECUTING"), 
+									fmt.Sprintf("🚀 %s %s %s",
+										style.ToolNameStyle.Render("EXECUTING"),
 										style.HighlightStyle.Render(toolName),
 										style.ToolStatsStyle.Render(statsStr))))
-								
+
 								if toolArgs != "" {
 									prettyArgs := toolArgs
 									if json.Valid([]byte(toolArgs)) {
@@ -782,7 +834,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 									}
 									fmt.Printf("%s\n", style.ToolArgsStyle.Render(fmt.Sprintf("📋 Parameters: %s", prettyArgs)))
 								}
-								
+
 								// Show waiting indicator with animation and runner info
 								fmt.Printf("%s\n", style.SpinnerStyle.Render(
 									fmt.Sprintf("⏳ Initializing on runner://%s...", connStatus.runner)))
@@ -796,24 +848,24 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 					if te != nil && !te.isComplete {
 						// Mark that we received output
 						te.hasOutput = true
-						
+
 						// Update status to running when we start receiving output
 						if te.status == "waiting" {
 							te.status = "running"
 							// Update the status display
 							fmt.Printf("\r%s\n", style.SpinnerStyle.Render("🔄 Processing tool execution..."))
 						}
-						
+
 						// Also check if we need to mark as complete based on content
-						if strings.Contains(strings.ToLower(msg.Content), "completed") || 
-						   strings.Contains(strings.ToLower(msg.Content), "finished") ||
-						   strings.Contains(strings.ToLower(msg.Content), "done") {
+						if strings.Contains(strings.ToLower(msg.Content), "completed") ||
+							strings.Contains(strings.ToLower(msg.Content), "finished") ||
+							strings.Contains(strings.ToLower(msg.Content), "done") {
 							te.isComplete = true
 						}
-						
+
 						// Store the full content
 						te.output.WriteString(msg.Content)
-						
+
 						// Get the current content buffer for this message
 						storedContent := messageBuffer[msg.MessageID]
 						if storedContent == nil {
@@ -905,7 +957,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 								}
 							}
 						}
-						
+
 						// Update stored content
 						storedContent.content = msg.Content
 					}
@@ -921,7 +973,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 								// If running for more than 30 seconds without completion, mark as complete
 								te.isComplete = true
 							}
-							
+
 							if te.isComplete {
 								// Update tool statistics
 								toolStats.mu.Lock()
@@ -932,7 +984,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 									toolStats.completedCalls++
 								}
 								toolStats.mu.Unlock()
-								
+
 								duration := time.Since(te.startTime).Seconds()
 
 								// Determine status emoji and completion message
@@ -948,7 +1000,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 
 								// Show updated statistics
 								toolStats.mu.RLock()
-								updatedStatsStr := fmt.Sprintf("[%d active, %d completed, %d failed]", 
+								updatedStatsStr := fmt.Sprintf("[%d active, %d completed, %d failed]",
 									toolStats.activeCalls, toolStats.completedCalls, toolStats.failedCalls)
 								toolStats.mu.RUnlock()
 
@@ -1072,9 +1124,9 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 				if debug {
 					fmt.Printf("🔄 No tools executed, sending follow-up prompt\n")
 				}
-				
+
 				followUpMsg := "You didn't seem to execute anything. You're running in a non-interactive session and the user confirms to execute read-only operations. EXECUTE RIGHT AWAY!"
-				
+
 				// Send follow-up message
 				followUpChan, err := client.SendMessageWithContext(cmd.Context(), agentID, followUpMsg, actualSessionID, map[string]string{})
 				if err != nil {
@@ -1083,11 +1135,11 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 					}
 				} else {
 					fmt.Printf("\n%s\n", style.InfoBoxStyle.Render("🔄 Following up to ensure execution..."))
-					
+
 					// Process follow-up response
 					for msg := range followUpChan {
 						if msg.Error != "" {
-							fmt.Fprintf(os.Stderr, "%s\n", style.ErrorStyle.Render("❌ Error: " + msg.Error))
+							fmt.Fprintf(os.Stderr, "%s\n", style.ErrorStyle.Render("❌ Error: "+msg.Error))
 							hasError = true
 							break
 						}
@@ -1105,7 +1157,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 			// Show session continuation message
 			if !interactive && actualSessionID != "" {
 				fmt.Printf("\n%s\n", style.InfoBoxStyle.Render("💬 To continue this conversation, run:"))
-				
+
 				// Include agent name in the continuation command if available
 				var continuationCmd string
 				if agentName != "" {
@@ -1115,7 +1167,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 				} else {
 					continuationCmd = fmt.Sprintf("kubiya chat --session %s -m \"your message here\"", actualSessionID)
 				}
-				
+
 				fmt.Printf("%s\n", style.HighlightStyle.Render(continuationCmd))
 				fmt.Println()
 			}
@@ -1124,7 +1176,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 			if debug {
 				fmt.Printf("🔍 Completion reason: %s, hasError: %v, toolsExecuted: %v\n", completionReason, hasError, toolsExecuted)
 			}
-			
+
 			// Return proper exit code based on completion status
 			if hasError {
 				if debug {
@@ -1132,7 +1184,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 				}
 				return fmt.Errorf("agent execution completed with errors")
 			}
-			
+
 			// Check for non-successful completion reasons
 			switch completionReason {
 			case "error":
@@ -1172,7 +1224,7 @@ For inline agents, use --inline with --tools-file or --tools-json to provide cus
 	cmd.Flags().StringVar(&suggestTool, "suggest-tool", "", "Suggest a tool to use")
 	cmd.Flags().BoolVar(&noClassify, "no-classify", false, "Disable automatic agent classification")
 	cmd.Flags().StringVar(&permissionLevel, "permission-level", "read", "Permission level for tool execution (read, readwrite, ask)")
-	
+
 	// Inline agent flags
 	cmd.Flags().BoolVar(&inline, "inline", false, "Use inline agent mode")
 	cmd.Flags().StringVar(&toolsFile, "tools-file", "", "JSON file containing tools definition")

--- a/internal/kubiya/chat.go
+++ b/internal/kubiya/chat.go
@@ -128,6 +128,16 @@ func (c *Client) SendMessage(ctx context.Context, agentID, message string, sessi
 		sessionID = session.ID
 	}
 
+	// Get user email and org from environment variables with fallback to config
+	userEmail := os.Getenv("KUBIYA_USER_EMAIL")
+	org := os.Getenv("KUBIYA_ORG")
+	if userEmail == "" {
+		userEmail = c.cfg.Email
+	}
+	if org == "" {
+		org = c.cfg.Org
+	}
+	
 	payload := struct {
 		Message   string `json:"message"`
 		AgentUUID string `json:"agent_uuid"`
@@ -138,17 +148,26 @@ func (c *Client) SendMessage(ctx context.Context, agentID, message string, sessi
 		Message:   message,
 		AgentUUID: agentID,
 		SessionID: sessionID,
-		UserEmail: os.Getenv("KUBIYA_USER_EMAIL"),
-		Org:       os.Getenv("KUBIYA_ORG"),
+		UserEmail: userEmail,
+		Org:       org,
 	}
 
+	reqURL := fmt.Sprintf("%s/hb/v4/stream", c.baseURL)
+	
 	// Safety check for logger
 	if logger != nil {
 		logger.Printf("=== Starting SendMessage ===")
 		logger.Printf("Payload: %+v", payload)
+		
+		// Log the complete request details for debugging
+		if jsonPayload, err := json.MarshalIndent(payload, "", "  "); err == nil {
+			logger.Printf("Complete request payload: %s", string(jsonPayload))
+		}
+		
+		logger.Printf("Request URL: %s", reqURL)
+		logger.Printf("User Email: %s", os.Getenv("KUBIYA_USER_EMAIL"))
+		logger.Printf("Organization: %s", os.Getenv("KUBIYA_ORG"))
 	}
-
-	reqURL := fmt.Sprintf("%s/hb/v4/stream", c.baseURL)
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		if logger != nil {
@@ -170,8 +189,26 @@ func (c *Client) SendMessage(ctx context.Context, agentID, message string, sessi
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-vercel-ai-data-stream", "v1") // protocol flag
 	req.Header.Set("Authorization", "UserKey "+c.cfg.APIKey)
-	req.Header.Set("Cache-Control", "no-cache")
-	req.Header.Set("Connection", "keep-alive")
+	// Remove extra headers to match working Go program
+	// req.Header.Set("Cache-Control", "no-cache")
+	// req.Header.Set("Connection", "keep-alive")
+	
+	// Log all request headers for debugging
+	if logger != nil {
+		logger.Printf("=== Request Headers ===")
+		for key, values := range req.Header {
+			for _, value := range values {
+				// Mask sensitive Authorization header
+				if key == "Authorization" {
+					logger.Printf("%s: %s", key, "UserKey [REDACTED]")
+				} else {
+					logger.Printf("%s: %s", key, value)
+				}
+			}
+		}
+		logger.Printf("=== End Headers ===")
+		logger.Printf("Request body length: %d bytes", len(jsonData))
+	}
 
 	client := &http.Client{Timeout: 0} // No timeout for streaming
 
@@ -191,13 +228,38 @@ func (c *Client) SendMessage(ctx context.Context, agentID, message string, sessi
 		}
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
+	
+	// Log successful response details
+	if logger != nil {
+		logger.Printf("=== HTTP Response Success ===")
+		logger.Printf("Status Code: %d", resp.StatusCode)
+		logger.Printf("Status: %s", resp.Status)
+		logger.Printf("Response Headers:")
+		for key, values := range resp.Header {
+			for _, value := range values {
+				logger.Printf("  %s: %s", key, value)
+			}
+		}
+		logger.Printf("Starting stream processing...")
+		logger.Printf("=== End HTTP Response Success ===")
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		close(messagesChan)
 		if logger != nil {
-			logger.Printf("Unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+			logger.Printf("=== HTTP Response Error ===")
+			logger.Printf("Status Code: %d", resp.StatusCode)
+			logger.Printf("Status: %s", resp.Status)
+			logger.Printf("Response Headers:")
+			for key, values := range resp.Header {
+				for _, value := range values {
+					logger.Printf("  %s: %s", key, value)
+				}
+			}
+			logger.Printf("Response body: %s", string(body))
+			logger.Printf("=== End HTTP Response Error ===")
 		}
 		
 		// Provide user-friendly error messages based on status code
@@ -306,6 +368,11 @@ func (c *Client) SendMessage(ctx context.Context, agentID, message string, sessi
 			// Print raw events for debugging (when debug mode is enabled)
 			if os.Getenv("KUBIYA_DEBUG") == "1" || os.Getenv("DEBUG") == "1" || os.Getenv("KUBIYA_RAW_EVENTS") == "1" {
 				fmt.Printf("[RAW STREAM EVENT] %s\n", line)
+			}
+			
+			// Also log to file for detailed debugging
+			if logger != nil {
+				logger.Printf("[STREAM] Line %d: %s", lineCount, line)
 			}
 
 			// Handle empty lines gracefully
@@ -650,29 +717,56 @@ func (c *Client) SendInlineAgentMessage(ctx context.Context, message, sessionID 
 		sessionID = uuid.New().String()
 	}
 	
+	
+	
+	
+	// Log session and user details
+	if logger != nil {
+		logger.Printf("Session ID: %s", sessionID)
+		logger.Printf("User Email: %s", os.Getenv("KUBIYA_USER_EMAIL"))
+		logger.Printf("Organization: %s", os.Getenv("KUBIYA_ORG"))
+	}
+	
+	// Get user email and org from environment variables with fallback to config
+	userEmail := os.Getenv("KUBIYA_USER_EMAIL")
+	org := os.Getenv("KUBIYA_ORG")
+	if userEmail == "" {
+		userEmail = c.cfg.Email
+	}
+	if org == "" {
+		org = c.cfg.Org
+	}
+	
 	payload := struct {
 		Message   string                 `json:"message"`
 		SessionID string                 `json:"session_id"`
-		UserUUID  string                 `json:"user_uuid"`
 		UserEmail string                 `json:"user_email"`
 		Org       string                 `json:"org"`
 		Agent     map[string]interface{} `json:"agent"`
 	}{
 		Message:   contextMsg.String(),
 		SessionID: sessionID,
-		UserUUID:  uuid.New().String(),
-		UserEmail: os.Getenv("KUBIYA_USER_EMAIL"),
-		Org:       os.Getenv("KUBIYA_ORG"),
+		UserEmail: userEmail,
+		Org:       org,
 		Agent:     agentDef,
 	}
 
+	reqURL := fmt.Sprintf("%s/hb/v4/stream", c.baseURL)
+	
 	// Safety check for logger
 	if logger != nil {
 		logger.Printf("=== Starting SendInlineAgentMessage ===")
 		logger.Printf("Payload: %+v", payload)
+		
+		// Log the complete request details for debugging
+		if jsonPayload, err := json.MarshalIndent(payload, "", "  "); err == nil {
+			logger.Printf("Complete request payload: %s", string(jsonPayload))
+		}
+		
+		logger.Printf("Request URL: %s", reqURL)
+		logger.Printf("User Email: %s", os.Getenv("KUBIYA_USER_EMAIL"))
+		logger.Printf("Organization: %s", os.Getenv("KUBIYA_ORG"))
 	}
-
-	reqURL := fmt.Sprintf("%s/hb/v4/stream", c.baseURL)
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		if logger != nil {
@@ -692,10 +786,27 @@ func (c *Client) SendInlineAgentMessage(ctx context.Context, message, sessionID 
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-vercel-ai-data-stream", "v1") // protocol flag
 	req.Header.Set("Authorization", "UserKey "+c.cfg.APIKey)
-	req.Header.Set("Cache-Control", "no-cache")
-	req.Header.Set("Connection", "keep-alive")
+	// Remove extra headers to match working Go program
+	// req.Header.Set("Cache-Control", "no-cache")
+	// req.Header.Set("Connection", "keep-alive")
+	
+	// Log all request headers for debugging
+	if logger != nil {
+		logger.Printf("=== Request Headers ===")
+		for key, values := range req.Header {
+			for _, value := range values {
+				// Mask sensitive Authorization header
+				if key == "Authorization" {
+					logger.Printf("%s: %s", key, "UserKey [REDACTED]")
+				} else {
+					logger.Printf("%s: %s", key, value)
+				}
+			}
+		}
+		logger.Printf("=== End Headers ===")
+		logger.Printf("Request body length: %d bytes", len(jsonData))
+	}
 
 	client := &http.Client{Timeout: 0}
 
@@ -713,13 +824,33 @@ func (c *Client) SendInlineAgentMessage(ctx context.Context, message, sessionID 
 		resp.Body.Close()
 		close(messagesChan)
 		if logger != nil {
-			logger.Printf("Unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+			logger.Printf("=== HTTP Response Error ===")
+			logger.Printf("Status Code: %d", resp.StatusCode)
+			logger.Printf("Status: %s", resp.Status)
+			logger.Printf("Response Headers:")
+			for key, values := range resp.Header {
+				for _, value := range values {
+					logger.Printf("  %s: %s", key, value)
+				}
+			}
+			logger.Printf("Response body: %s", string(body))
+			logger.Printf("=== End HTTP Response Error ===")
 		}
 		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 	
 	if logger != nil {
-		logger.Printf("HTTP request successful, status: %d, starting stream processing", resp.StatusCode)
+		logger.Printf("=== HTTP Response Success ===")
+		logger.Printf("Status Code: %d", resp.StatusCode)
+		logger.Printf("Status: %s", resp.Status)
+		logger.Printf("Response Headers:")
+		for key, values := range resp.Header {
+			for _, value := range values {
+				logger.Printf("  %s: %s", key, value)
+			}
+		}
+		logger.Printf("Starting stream processing...")
+		logger.Printf("=== End HTTP Response Success ===")
 	}
 
 	go func() {
@@ -809,6 +940,11 @@ func (c *Client) SendInlineAgentMessage(ctx context.Context, message, sessionID 
 			// Print raw events for debugging (when debug mode is enabled)
 			if os.Getenv("KUBIYA_DEBUG") == "1" || os.Getenv("DEBUG") == "1" || os.Getenv("KUBIYA_RAW_EVENTS") == "1" {
 				fmt.Printf("[RAW STREAM EVENT] %s\n", line)
+			}
+			
+			// Also log to file for detailed debugging
+			if logger != nil {
+				logger.Printf("[STREAM] Line %d: %s", lineCount, line)
 			}
 
 			// Handle empty lines gracefully


### PR DESCRIPTION
# CORE-1164: Enable Inline Agent Flow in cli
## Description
Enhanced the CLI's inline agent functionality to properly handle tool execution and output display, ensuring workflows can define and execute agents in place with reliable tool output capture.

## Implementation Details
- Fixed tool payload serialization: `args`, `env`, `with_files`, `with_volumes` now use empty arrays instead of null
- Removed unnecessary fields (`icon_url`, `mermaid`, `secrets`) from tool payload to match API expectations
- Set `is_debug_mode` to true for inline agents to ensure tool output is captured regardless of CLI debug settings
- Enhanced debug logging for request/response analysis and troubleshooting
- Fixed environment variable handling for `user_email` and `org` fields
- Added proper runner configuration support for different execution environments

## Testing
- Verified inline agent tool execution works with and without debug mode
- Confirmed tool output is properly displayed to users in both modes
- Tested payload structure matches API expectations and reduces errors
- Validated runner configuration handling (`core-testing-2` vs `kubiyamanaged`)
- Ensured backward compatibility with existing inline agent usage

## Dependencies
- No new dependencies added
- Changes are backward compatible
- Tool output display now works consistently across different debug modes

Closes CORE-1164

```go
 ./kubiya-cli chat --inline --tools-json '[{"name":"raz-echo","alias":"raz-echo","description":"Echo raz to the terminal","type":"docker","content":"echo RAZAAAZAAZAZAZAZA","image":"alpine:latest"}]' --runners "core-testing-2"  -m "run raz-echo"
 ```
<img width="2200" height="617" alt="image" src="https://github.com/user-attachments/assets/782aa637-7b66-47b1-9506-982d4b6c7b4a" />
