### PR TITLE
fix(exec): Default streaming to text format for all environments

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -172,7 +172,7 @@ All plans are automatically saved to ~/.kubiya/plans/ for future reference.`,
 
 	// Streaming flags (streaming is enabled by default)
 	cmd.Flags().BoolVar(&noStream, "no-stream", false, "Disable live event streaming (streaming is enabled by default)")
-	cmd.Flags().StringVar(&streamFormat, "stream-format", "auto", "Stream output format: auto, text, json (auto: text for TTY, json for CI/pipes)")
+	cmd.Flags().StringVar(&streamFormat, "stream-format", "auto", "Stream output format: auto, text, json (default: text for all environments)")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show detailed tool inputs and outputs in streaming mode")
 
 	// Execution mode flags

--- a/internal/cli/exec_streaming.go
+++ b/internal/cli/exec_streaming.go
@@ -47,6 +47,8 @@ func resolveStreamOptions(noStreamFlag bool, streamFormat string, verbose bool) 
 }
 
 // resolveStreamFormat determines the actual format to use
+// Text format is the default for all environments (TTY, CI, pipes) for better readability
+// Use --stream-format=json explicitly when programmatic parsing is needed
 func resolveStreamFormat(explicit string) streaming.StreamFormat {
 	switch explicit {
 	case "text":
@@ -54,19 +56,11 @@ func resolveStreamFormat(explicit string) streaming.StreamFormat {
 	case "json":
 		return streaming.StreamFormatJSON
 	case "auto", "":
-		// Auto-detect based on environment
-		if output.IsCI() {
-			return streaming.StreamFormatJSON
-		}
-		// Check if stderr is a TTY
-		if isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd()) {
-			return streaming.StreamFormatText
-		}
-		// Default to JSON for pipes
-		return streaming.StreamFormatJSON
+		// Default to text for all environments - more readable in CI logs and terminals
+		return streaming.StreamFormatText
 	default:
-		// Unknown format, default to auto behavior
-		return streaming.StreamFormatJSON
+		// Unknown format, default to text
+		return streaming.StreamFormatText
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change default streaming format from JSON to text for all environments (TTY, CI, pipes)
- Text format is more readable in CI logs
- Use `--stream-format=json` explicitly when programmatic parsing is needed

## Changes
- Updated `resolveStreamFormat()` to default to text instead of JSON
- Updated help text to reflect the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)