### PR TITLE
feat(exec): add --find flag for fuzzy entity matching

### DIFF
--- a/internal/cli/entity_matcher.go
+++ b/internal/cli/entity_matcher.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kubiyabot/cli/internal/controlplane/entities"
+	"github.com/lithammer/fuzzysearch/fuzzy"
+)
+
+// EntityMatch represents a matched entity with its score
+type EntityMatch struct {
+	Entity     interface{} // *entities.Agent or *entities.Team
+	EntityType string      // "agent" or "team"
+	EntityID   string
+	EntityName string
+	Score      float64
+	MatchedOn  []string // Fields that matched: "name", "description", "capabilities"
+}
+
+// EntityMatcher handles fuzzy matching of agents and teams
+type EntityMatcher struct {
+	agents []*entities.Agent
+	teams  []*entities.Team
+}
+
+// NewEntityMatcher creates a matcher with the given entities
+func NewEntityMatcher(agents []*entities.Agent, teams []*entities.Team) *EntityMatcher {
+	return &EntityMatcher{
+		agents: agents,
+		teams:  teams,
+	}
+}
+
+// FindMatches searches for entities matching the pattern
+// Returns matches sorted by score (highest first)
+func (m *EntityMatcher) FindMatches(pattern string, threshold float64) []EntityMatch {
+	var matches []EntityMatch
+
+	// Search agents
+	for _, agent := range m.agents {
+		score, matchedOn := m.calculateAgentScore(pattern, agent)
+		if score >= threshold {
+			matches = append(matches, EntityMatch{
+				Entity:     agent,
+				EntityType: "agent",
+				EntityID:   agent.ID,
+				EntityName: agent.Name,
+				Score:      score,
+				MatchedOn:  matchedOn,
+			})
+		}
+	}
+
+	// Search teams
+	for _, team := range m.teams {
+		score, matchedOn := m.calculateTeamScore(pattern, team)
+		if score >= threshold {
+			matches = append(matches, EntityMatch{
+				Entity:     team,
+				EntityType: "team",
+				EntityID:   team.ID,
+				EntityName: team.Name,
+				Score:      score,
+				MatchedOn:  matchedOn,
+			})
+		}
+	}
+
+	// Sort by score (highest first)
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Score > matches[j].Score
+	})
+
+	return matches
+}
+
+// calculateAgentScore computes weighted fuzzy score for an agent
+// Weights: Name (3x), Description (2x), Capabilities (1x)
+func (m *EntityMatcher) calculateAgentScore(pattern string, agent *entities.Agent) (float64, []string) {
+	var totalScore float64
+	var matchedFields []string
+	patternLower := strings.ToLower(pattern)
+
+	// Check for exact name match first (case-insensitive)
+	if strings.EqualFold(agent.Name, pattern) {
+		return 1.0, []string{"name (exact)"}
+	}
+
+	// Name matching (weight: 3)
+	nameScore := m.fuzzyScore(patternLower, strings.ToLower(agent.Name))
+	if nameScore > 0 {
+		totalScore += nameScore * 3.0
+		matchedFields = append(matchedFields, "name")
+	}
+
+	// Description matching (weight: 2)
+	if agent.Description != nil && *agent.Description != "" {
+		descScore := m.fuzzyScore(patternLower, strings.ToLower(*agent.Description))
+		if descScore > 0 {
+			totalScore += descScore * 2.0
+			matchedFields = append(matchedFields, "description")
+		}
+	}
+
+	// Capabilities matching (weight: 1) - best match among all capabilities
+	var bestCapScore float64
+	for _, cap := range agent.Capabilities {
+		capScore := m.fuzzyScore(patternLower, strings.ToLower(cap))
+		if capScore > bestCapScore {
+			bestCapScore = capScore
+		}
+	}
+	if bestCapScore > 0 {
+		totalScore += bestCapScore * 1.0
+		matchedFields = append(matchedFields, "capabilities")
+	}
+
+	// Normalize by max possible score (3 + 2 + 1 = 6)
+	normalizedScore := totalScore / 6.0
+
+	return normalizedScore, matchedFields
+}
+
+// calculateTeamScore computes weighted fuzzy score for a team
+// Weights: Name (3x), Description (2x), TeamType (1x)
+func (m *EntityMatcher) calculateTeamScore(pattern string, team *entities.Team) (float64, []string) {
+	var totalScore float64
+	var matchedFields []string
+	patternLower := strings.ToLower(pattern)
+
+	// Check for exact name match first (case-insensitive)
+	if strings.EqualFold(team.Name, pattern) {
+		return 1.0, []string{"name (exact)"}
+	}
+
+	// Name matching (weight: 3)
+	nameScore := m.fuzzyScore(patternLower, strings.ToLower(team.Name))
+	if nameScore > 0 {
+		totalScore += nameScore * 3.0
+		matchedFields = append(matchedFields, "name")
+	}
+
+	// Description matching (weight: 2)
+	if team.Description != nil && *team.Description != "" {
+		descScore := m.fuzzyScore(patternLower, strings.ToLower(*team.Description))
+		if descScore > 0 {
+			totalScore += descScore * 2.0
+			matchedFields = append(matchedFields, "description")
+		}
+	}
+
+	// TeamType matching (weight: 1)
+	if team.TeamType != nil && *team.TeamType != "" {
+		typeScore := m.fuzzyScore(patternLower, strings.ToLower(*team.TeamType))
+		if typeScore > 0 {
+			totalScore += typeScore * 1.0
+			matchedFields = append(matchedFields, "type")
+		}
+	}
+
+	// Normalize by max possible score (3 + 2 + 1 = 6)
+	normalizedScore := totalScore / 6.0
+
+	return normalizedScore, matchedFields
+}
+
+// fuzzyScore calculates a score between 0 and 1 for how well pattern matches target
+// Uses substring matching and fuzzy matching for flexibility
+func (m *EntityMatcher) fuzzyScore(pattern, target string) float64 {
+	if pattern == "" || target == "" {
+		return 0
+	}
+
+	// Exact substring match gets highest score
+	if strings.Contains(target, pattern) {
+		// Score based on how much of the target the pattern covers
+		return 0.8 + (0.2 * float64(len(pattern)) / float64(len(target)))
+	}
+
+	// Check if pattern is contained in target using fuzzy matching
+	if fuzzy.Match(pattern, target) {
+		// Use RankMatch to get distance - lower is better
+		distance := fuzzy.RankMatch(pattern, target)
+		if distance >= 0 {
+			// Convert distance to score: 0 distance = 1.0 score, higher distance = lower score
+			return 1.0 / (1.0 + float64(distance)*0.1)
+		}
+	}
+
+	// No match
+	return 0
+}

--- a/internal/cli/entity_selector.go
+++ b/internal/cli/entity_selector.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	entityTitleStyle        = lipgloss.NewStyle().MarginLeft(2).Bold(true)
+	entityItemStyle         = lipgloss.NewStyle().PaddingLeft(4)
+	entitySelectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
+	entityDescStyle         = lipgloss.NewStyle().PaddingLeft(6).Foreground(lipgloss.Color("241"))
+	entityPaginationStyle   = list.DefaultStyles().PaginationStyle.PaddingLeft(4)
+	entityHelpStyle         = list.DefaultStyles().HelpStyle.PaddingLeft(4).PaddingBottom(1)
+)
+
+// entitySelectItem implements list.Item for matched entities
+type entitySelectItem struct {
+	match EntityMatch
+}
+
+func (i entitySelectItem) Title() string {
+	icon := "🤖"
+	if i.match.EntityType == "team" {
+		icon = "👥"
+	}
+	return fmt.Sprintf("%s %s (Score: %.0f%%)", icon, i.match.EntityName, i.match.Score*100)
+}
+
+func (i entitySelectItem) Description() string {
+	matchedOn := strings.Join(i.match.MatchedOn, ", ")
+	return fmt.Sprintf("Matched: %s", matchedOn)
+}
+
+func (i entitySelectItem) FilterValue() string {
+	return i.match.EntityName
+}
+
+// entitySelectDelegate handles rendering of entity items
+type entitySelectDelegate struct{}
+
+func (d entitySelectDelegate) Height() int  { return 2 }
+func (d entitySelectDelegate) Spacing() int { return 1 }
+func (d entitySelectDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd {
+	return nil
+}
+
+func (d entitySelectDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(entitySelectItem)
+	if !ok {
+		return
+	}
+
+	title := i.Title()
+	desc := i.Description()
+
+	if index == m.Index() {
+		// Selected item
+		fmt.Fprint(w, entitySelectedItemStyle.Render("> "+title)+"\n")
+		fmt.Fprint(w, entityDescStyle.Render("  "+desc))
+	} else {
+		// Non-selected item
+		fmt.Fprint(w, entityItemStyle.Render(title)+"\n")
+		fmt.Fprint(w, entityDescStyle.Render(desc))
+	}
+}
+
+// entitySelectModel is the bubbletea model for entity selection
+type entitySelectModel struct {
+	list     list.Model
+	matches  []EntityMatch
+	selected *EntityMatch
+	quitting bool
+}
+
+func (m entitySelectModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m entitySelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.list.SetWidth(msg.Width)
+		return m, nil
+
+	case tea.KeyMsg:
+		switch keypress := msg.String(); keypress {
+		case "ctrl+c", "q", "esc":
+			m.quitting = true
+			m.selected = nil
+			return m, tea.Quit
+
+		case "enter":
+			if i, ok := m.list.SelectedItem().(entitySelectItem); ok {
+				m.selected = &i.match
+				m.quitting = true
+			}
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m entitySelectModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	return "\n" + m.list.View()
+}
+
+// ShowEntitySelector displays interactive selection UI
+// Returns selected match or nil if cancelled
+func ShowEntitySelector(matches []EntityMatch) (*EntityMatch, error) {
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no matches to select from")
+	}
+
+	// Convert matches to list items
+	items := make([]list.Item, len(matches))
+	for i, match := range matches {
+		items[i] = entitySelectItem{match: match}
+	}
+
+	// Calculate list dimensions
+	const defaultWidth = 60
+	listHeight := len(matches)*3 + 6 // 3 lines per item + header/footer
+	if listHeight > 20 {
+		listHeight = 20
+	}
+
+	l := list.New(items, entitySelectDelegate{}, defaultWidth, listHeight)
+	l.Title = fmt.Sprintf("Select Agent or Team (%d matches)", len(matches))
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(true)
+	l.Styles.Title = entityTitleStyle
+	l.Styles.PaginationStyle = entityPaginationStyle
+	l.Styles.HelpStyle = entityHelpStyle
+
+	m := entitySelectModel{
+		list:    l,
+		matches: matches,
+	}
+
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return nil, fmt.Errorf("error running selector: %w", err)
+	}
+
+	if fm, ok := finalModel.(entitySelectModel); ok {
+		return fm.selected, nil
+	}
+
+	return nil, fmt.Errorf("unexpected model type")
+}


### PR DESCRIPTION
## Summary

- Add `--find` / `-f` flag to `kubiya exec` command for fuzzy entity (agent/team) matching
- Enables direct execution by name without relying on the planner
- Uses weighted similarity scoring across name, description, and capabilities
- Interactive selection UI when multiple matches are found

## Usage

```bash
# Fuzzy entity matching (bypasses planner)
kubiya exec --find "kubernetes" "Deploy my app"
kubiya exec -f "k8s-deploy" "Check pod status"
kubiya exec --find "security" "Scan for vulnerabilities"

# Non-interactive mode uses best match automatically
kubiya exec --find "kubernetes" --non-interactive "Deploy my app"
```

## Features

- **Weighted scoring**: Name (3x), Description (2x), Capabilities/Type (1x)
- **50% threshold** for matches
- **Interactive selection** when multiple matches found (bubbletea-based UI)
- **Auto-select** for single matches
- **Non-interactive mode** uses best match with warning about other candidates
- Searches both **agents** and **teams**

## Files Changed

| File | Description |
|------|-------------|
| `internal/cli/entity_matcher.go` | New - Fuzzy matching logic using `lithammer/fuzzysearch` |
| `internal/cli/entity_selector.go` | New - Interactive selection UI using bubbletea |
| `internal/cli/exec.go` | Modified - Added flag, routing, and `ExecuteWithEntityMatching` method |

## Test plan

- [ ] Run `kubiya exec --help` and verify `--find` flag appears
- [ ] Test with single match: `kubiya exec --find "<exact-agent-name>" "test"`
- [ ] Test with multiple matches: `kubiya exec --find "<partial-name>" "test"` (should show interactive selector)
- [ ] Test with no matches: `kubiya exec --find "nonexistent-xyz" "test"` (should show helpful error)
- [ ] Test non-interactive mode: `kubiya exec --find "<pattern>" --non-interactive "test"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)