### PR TITLE
COM-36: Add missing queue, parent, and cwd parameters to direct execution

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -1193,19 +1193,43 @@ func (ec *ExecCommand) ExecuteDirect(ctx context.Context, entityType, entityID, 
 	// Submit execution (use default queue for the entity's environment)
 	streamFlag := true
 
+	// Prepare optional fields
+	var queuePtr *string
+	if len(ec.QueueIDs) > 0 {
+		queuePtr = &ec.QueueIDs[0]
+	}
+
+	var parentExecPtr *string
+	if ec.ParentExecution != "" {
+		parentExecPtr = &ec.ParentExecution
+	}
+
+	var execEnv *entities.ExecutionEnvironmentOverride
+	if ec.Cwd != "" {
+		execEnv = &entities.ExecutionEnvironmentOverride{
+			WorkingDir: ec.Cwd,
+		}
+	}
+
 	var execution *entities.AgentExecution
 	var err error
 
 	if entityType == "agent" {
 		req := &entities.ExecuteAgentRequest{
-			Prompt: prompt,
-			Stream: &streamFlag,
+			Prompt:               prompt,
+			WorkerQueueID:        queuePtr,
+			ParentExecutionID:    parentExecPtr,
+			Stream:               &streamFlag,
+			ExecutionEnvironment: execEnv,
 		}
 		execution, err = ec.client.ExecuteAgentV2(entityID, req)
 	} else {
 		req := &entities.ExecuteTeamRequest{
-			Prompt: prompt,
-			Stream: &streamFlag,
+			Prompt:               prompt,
+			WorkerQueueID:        queuePtr,
+			ParentExecutionID:    parentExecPtr,
+			Stream:               &streamFlag,
+			ExecutionEnvironment: execEnv,
 		}
 		execution, err = ec.client.ExecuteTeamV2(entityID, req)
 	}


### PR DESCRIPTION
## Summary
Fixes direct execution mode (`kubiya exec agent/team <id> <prompt>`) to properly pass `--queue`, `--parent-execution`, and `--cwd` flags to the API.

## Problem
When using direct execution (bypassing the planner), commands like:
```bash
kubiya exec agent <agent-id> --queue "<queue-id>" "hey"
```

Failed with API error 422:
```json
{"detail":[{"type":"missing","loc":["body","worker_queue_id"],"msg":"Field required"}]}
```

The `--queue`, `--parent-execution`, and `--cwd` flags were being accepted by the CLI but completely ignored when creating the API request.

## Root Cause
**Location:** `internal/cli/exec.go` lines 1199-1210 in the `ExecuteDirect` function

The function was only sending `Prompt` and `Stream` fields to the API:
```go
req := &entities.ExecuteAgentRequest{
    Prompt: prompt,
    Stream: &streamFlag,
    // ❌ WorkerQueueID missing!
    // ❌ ParentExecutionID missing!
    // ❌ ExecutionEnvironment missing!
}
```

Meanwhile, the planning-based execution path (`submitAndStreamExecution`) was correctly including these fields.

## Solution
Added the same field preparation logic used in `submitAndStreamExecution`:
- **WorkerQueueID**: Set from `ec.QueueIDs[0]` when `--queue` flag is provided
- **ParentExecutionID**: Set from `ec.ParentExecution` when `--parent-execution` flag is provided  
- **ExecutionEnvironment**: Set with `WorkingDir` from `ec.Cwd` when `--cwd` flag is provided

Applied to both agent and team execution requests for consistency.

## Testing
✅ Built the CLI successfully
✅ Tested direct execution with queue: `./kubiya exec agent <id> --queue "<queue-id>" "tell me a joke"`
✅ Verified no more 422 errors
✅ Confirmed execution started and agent responded successfully
✅ Verified the fix matches the pattern used in `submitAndStreamExecution`

## Test Plan
- [x] Build the CLI
- [x] Test `kubiya exec agent <id> --queue <queue-id> "prompt"`
- [x] Verify execution starts without 422 error
- [x] Verify agent responds correctly
- [x] Check that flags are now passed to API

🤖 Generated with [Claude Code](https://claude.com/claude-code)